### PR TITLE
Added refactoring for multiple lets

### DIFF
--- a/src/parser/Language/Haskell/Tools/Parser/LetRefactoring.hs
+++ b/src/parser/Language/Haskell/Tools/Parser/LetRefactoring.hs
@@ -1,0 +1,66 @@
+module Language.Haskell.Tools.Parser.LetRefactoring where
+
+import Language.Haskell.Tools.AST
+import Language.Haskell.Tools.Refactor
+import Language.Haskell.Tools.PrettyPrint
+import Data.List
+import GHC
+import Control.Reference
+import Language.Haskell.Tools.Parser.ParseModule
+
+removeMultiLets :: String -> String -> IO ()
+removeMultiLets modulePath moduleName = do
+    moduleAST <- moduleParser modulePath moduleName
+    newAST <- (!~) (biplateRef) (letRefactor) (moduleAST)
+    writeFile moduleName (prettyPrint newAST)
+
+-- Get all let statements, Group and Refactor
+letRefactor :: Ann UDecl (Dom GhcPs) SrcTemplateStage -> IO (Ann UDecl (Dom GhcPs) SrcTemplateStage)
+letRefactor expr@(Ann _ (UValueBinding sim@(Ann _ (USimpleBind pat rhs@(Ann _ (UUnguardedRhs y@(Ann _ ((UDo _ stmts@(AnnListG _ ex)))))) (AnnMaybeG _ binds))))) =
+    let groupedStmts = groupBy (\a b -> checkIfLet a && checkIfLet b) ex
+        modifiedStmts = concat $ map modifiyStmts groupedStmts
+        doBlock = mkDoBlock' modifiedStmts
+        makeRhs = mkUnguardedRhs' doBlock
+        simpleBind = mkSimpleBinds pat makeRhs binds
+    in pure $ mkValueBinding' simpleBind
+
+-- Modify if let statement
+modifiyStmts :: [Ann UStmt (Dom GhcPs) SrcTemplateStage] -> [Ann UStmt (Dom GhcPs) SrcTemplateStage]
+modifiyStmts expr =
+    if (checkIfLet $ head expr)
+        then modifyLets expr
+        else expr
+
+checkIfLet :: Ann UStmt (Dom GhcPs) SrcTemplateStage -> Bool
+checkIfLet (Ann _ (ULetStmt _)) = True
+checkIfLet _ = False
+
+-- Let modifications
+modifyLets :: [Ann UStmt (Dom GhcPs) SrcTemplateStage] -> [Ann UStmt (Dom GhcPs) SrcTemplateStage]
+modifyLets expr =
+    let (Ann _ (ULetStmt (AnnListG _ ex))) = head expr
+        otherExpr = map getLocalBinding $ tail expr
+    in [mkLetStmt' $ (ex ++ (concat otherExpr))]
+  where
+    getLocalBinding (Ann _ (ULetStmt (AnnListG _ expr))) = expr
+
+{- Example code:
+
+getAllNames = do
+  let a = "hi"
+  let b = "hello"
+  let c = "mike"
+  d <- pure "bbb"
+  let h = "in"
+  let k = "lll"
+  a <> b <> c <> h <> k
+
+Refactored code
+
+getAllNames = do let a = "hi"
+                     b = "hello"
+                     c = "mike"
+                 d <- pure "bbb"
+                 let h = "in"
+                     k = "lll"
+                 a <> b <> c <> h <> k -}

--- a/src/parser/Language/Haskell/Tools/Parser/ProgramOptions.hs
+++ b/src/parser/Language/Haskell/Tools/Parser/ProgramOptions.hs
@@ -10,7 +10,7 @@ data Options =
     { optCommand :: ParseConfig
     }
 
-data ASTRefactors = FunctionDependency | Other
+data ASTRefactors = FunctionDependency | LetRefactoring
   deriving (Show)
 
 data ParseConfig = Refact ASTParseConfig | SplitAndWrite WriteFileConfig
@@ -38,6 +38,7 @@ data WriteFileConfig =
 opts :: Parser ParseConfig
 opts =
       subparser (command "getFunDeps" $ (info (parserConfig FunctionDependency) (progDesc "Get the function dependency graph of a module")))
+  <|> subparser (command "letRefactor" $ (info (parserConfig FunctionDependency) (progDesc "Multiple Let Refactoring")))
   <|> subparser (command "writeModSplits" $ (info writeFileConfig (progDesc "Split the grouped functions into modules")))
 
 parserConfig :: ASTRefactors -> Parser ParseConfig

--- a/src/parser/Language/Haskell/Tools/Parser/SplitModule.hs
+++ b/src/parser/Language/Haskell/Tools/Parser/SplitModule.hs
@@ -40,7 +40,8 @@ import Data.List
 import qualified Data.Map.Strict as SMap (empty, toList)
 
 import Debug.Trace (trace, traceShowId)
-
+import Language.Haskell.Tools.Debug.RangeDebug
+import Language.Haskell.Tools.Debug.RangeDebugInstances
 import Outputable
 import Language.Haskell.Tools.PrettyPrint
 
@@ -65,6 +66,9 @@ import qualified Data.HashMap.Strict as HM
 import System.IO
 import Control.Monad
 import qualified Data.Aeson as A
+
+import Language.Haskell.Tools.AST.Representation.Binds (ULocalBind)
+
 
 
 
@@ -165,3 +169,4 @@ getFunctionsCalledInFunction expr = do
 getFunctions' :: Ann UName (Dom GhcPs) SrcTemplateStage -> String
 getFunctions' expr@(Ann _ (UNormalName (Ann _ (UQualifiedName _ (Ann _ (UNamePart ex)))))) = ex
 getFunctions' expr = ""
+

--- a/src/parser/exe/Main.hs
+++ b/src/parser/exe/Main.hs
@@ -4,6 +4,7 @@ module Main where
 
 import Language.Haskell.Tools.Parser.ProgramOptions
 import Language.Haskell.Tools.Parser.SplitModule
+import Language.Haskell.Tools.Parser.LetRefactoring
 import Options.Applicative
 import Data.Functor (($>), void)
 
@@ -17,5 +18,5 @@ main = do
                     deps <- getFunctionDeps (modulePath astParseConfig) (moduleName astParseConfig)
                     print deps
                     pure ()
-                _ -> pure ()
+                LetRefactoring -> removeMultiLets (modulePath astParseConfig) (moduleName astParseConfig) $>  ()
         SplitAndWrite writeFileConfig -> void (splitAndWrite (modPath writeFileConfig) (modName writeFileConfig) (clusters writeFileConfig) (funDeps writeFileConfig))

--- a/src/rewrite/Language/Haskell/Tools/Rewrite/Create/Decls.hs
+++ b/src/rewrite/Language/Haskell/Tools/Rewrite/Create/Decls.hs
@@ -37,6 +37,8 @@ mkTypeSigDecl = mkAnn child . UTypeSigDecl
 mkValueBinding :: ValueBind -> Decl
 mkValueBinding = mkAnn child . UValueBinding
 
+mkValueBinding' :: ValueBind' -> Decl'
+mkValueBinding' = mkAnn' child . UValueBinding
 -- | Creates a Template Haskell splice declaration (@ $(generateDecls) @)
 mkSpliceDecl :: Splice -> Decl
 mkSpliceDecl = mkAnn child . USpliceDecl

--- a/src/rewrite/Language/Haskell/Tools/Rewrite/Create/Exprs.hs
+++ b/src/rewrite/Language/Haskell/Tools/Rewrite/Create/Exprs.hs
@@ -63,6 +63,9 @@ mkCase expr cases = mkAnn ("case " <> child <> " of " <> child) $ UCase expr (mk
 mkDoBlock :: [Stmt] -> Expr
 mkDoBlock stmts = mkAnn (child <> " " <> child) $ UDo (mkAnn "do" UDoKeyword) (mkAnnList (indented list) stmts)
 
+mkDoBlock' :: [Stmt'] -> Expr'
+mkDoBlock' stmts = mkAnn' (child <> " " <> child) $ UDo (mkAnn' "do" UDoKeyword) (mkAnnList' (indented list) stmts)
+
 -- | Create a mdo-notation expressions (@ mdo x <- act1; act2 @)
 mkMDoBlock :: [Stmt] -> Expr
 mkMDoBlock stmts = mkAnn (child <> " " <> child) $ UDo (mkAnn "mdo" UMDoKeyword) (mkAnnList (indented list) stmts)

--- a/src/rewrite/Language/Haskell/Tools/Rewrite/Create/Stmts.hs
+++ b/src/rewrite/Language/Haskell/Tools/Rewrite/Create/Stmts.hs
@@ -7,7 +7,7 @@ module Language.Haskell.Tools.Rewrite.Create.Stmts where
 
 import Language.Haskell.Tools.AST (UCompStmt(..), UListCompBody(..), UStmt'(..))
 import Language.Haskell.Tools.PrettyPrint.Prepare
-import Language.Haskell.Tools.Rewrite.Create.Utils (mkAnn, mkAnnList, mkAnnMaybe)
+import Language.Haskell.Tools.Rewrite.Create.Utils (mkAnn, mkAnnList, mkAnnMaybe, mkAnnList', mkAnn')
 import Language.Haskell.Tools.Rewrite.ElementTypes
 
 -- | Creates a binding statement (@ x <- action @)
@@ -21,6 +21,9 @@ mkExprStmt = mkAnn child . UExprStmt
 -- | Creates a let statement (@ let x = 3; y = 4 @)
 mkLetStmt :: [LocalBind] -> Stmt
 mkLetStmt = mkAnn ("let " <> child) . ULetStmt . mkAnnList (indented list)
+
+mkLetStmt' :: [LocalBind'] -> Stmt'
+mkLetStmt' = mkAnn' ("let " <> child) . ULetStmt . mkAnnList' (indented list)
 
 -- | Creates a recursive binding statement with (@ rec b <- f a c; c <- f b a @)
 mkRecStmt :: [Stmt] -> Stmt

--- a/src/rewrite/Language/Haskell/Tools/Rewrite/ElementTypes.hs
+++ b/src/rewrite/Language/Haskell/Tools/Rewrite/ElementTypes.hs
@@ -74,6 +74,7 @@ type LanguageExtension = Ann ULanguageExtension IdDom SrcTemplateStage
 
 -- | Haskell declaration
 type Decl = Ann UDecl IdDom SrcTemplateStage
+type Decl' = Ann UDecl (Dom GhcPs) SrcTemplateStage
 
 -- | The list of declarations that can appear in a typeclass
 type ClassBody = Ann UClassBody IdDom SrcTemplateStage
@@ -293,6 +294,7 @@ type ArrowApp = Ann UArrowAppl IdDom SrcTemplateStage
 
 -- | A statement in a do-notation
 type Stmt = Ann UStmt IdDom SrcTemplateStage
+type Stmt' = Ann UStmt (Dom GhcPs) SrcTemplateStage
 
 -- | Keywords @do@ or @mdo@ to start a do-block
 type DoKind = Ann UDoKind IdDom SrcTemplateStage


### PR DESCRIPTION
Added multple let refactoring

Example code:

getAllNames = do
  let a = "hi"
  let b = "hello"
  let c = "mike"
  d <- pure "bbb"
  let h = "in"
  let k = "lll"
  a <> b <> c <> h <> k

Refactored code:

getAllNames = do 
    let a = "hi"
        b = "hello"
        c = "mike"
    d <- pure "bbb"
    let h = "in"
        k = "lll"
    a <> b <> c <> h <> k